### PR TITLE
feat: add Railway configuration for server deployment

### DIFF
--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -1,0 +1,11 @@
+[phases.setup]
+nixPkgs = ["nodejs_24"]
+
+[phases.install]
+cmds = ["cd server && npm ci"]
+
+[phases.build]
+cmds = ["cd server && npm run build"]
+
+[start]
+cmd = "cd server && npm start"

--- a/railway.json
+++ b/railway.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://railway.app/railway.schema.json",
+  "build": {
+    "builder": "NIXPACKS",
+    "buildCommand": "cd server && npm install && npm run build"
+  },
+  "deploy": {
+    "startCommand": "cd server && npm start",
+    "restartPolicyType": "ON_FAILURE",
+    "restartPolicyMaxRetries": 10
+  }
+}


### PR DESCRIPTION
- Add nixpacks.toml to specify Node 24 and server directory
- Add railway.json with build and deploy commands
- Configure Railway to build from /server subdirectory

This fixes the issue where Railway was trying to build from project root and encountering client (React) dependencies instead of server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)